### PR TITLE
fixed the config error for eleven labs and better error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,10 +210,27 @@ def build_voice_attribute():
         stability = current_config["stability"] 
         similarity = current_config["similarity"]
         
+        # Ensure decimal format is preserved by converting to float and back to string
+        # This ensures "1.0" stays as "1.0" and doesn't become "1"
+        try:
+            speed_float = float(speed)
+            stability_float = float(stability)
+            similarity_float = float(similarity)
+            
+            # Format with one decimal place to ensure consistency
+            speed_formatted = f"{speed_float:.1f}"
+            stability_formatted = f"{stability_float:.1f}"
+            similarity_formatted = f"{similarity_float:.1f}"
+        except (ValueError, TypeError):
+            # Fallback to original string values if conversion fails
+            speed_formatted = speed
+            stability_formatted = stability
+            similarity_formatted = similarity
+        
         # Only add settings if they're not default values
         if speed != "1.1" or stability != "0.5" or similarity != "0.5":
-            voice_id += f"-{speed}_{stability}_{similarity}"
-    
+            voice_id += f"-{speed_formatted}_{stability_formatted}_{similarity_formatted}"
+    print(f"Using voice attribute: {voice_id}")
     return voice_id
 
 @app.get("/twiml")


### PR DESCRIPTION
This pull request improves the consistency of voice attribute formatting in the `build_voice_attribute` function. The main change is to ensure that numeric values for speed, stability, and similarity are always formatted with one decimal place, preventing values like `"1.0"` from being converted to `"1"`. This helps maintain a predictable and uniform format for voice attribute strings.

Formatting improvements:

* Added logic to convert `speed`, `stability`, and `similarity` to floats and format them with one decimal place, ensuring consistent representation.
* Updated the construction of the `voice_id` string to use the newly formatted values, so attributes like `"1.0"` are preserved as `"1.0"` rather than `"1"`.
* Included a fallback to use the original string values if conversion to float fails, improving robustness.
* Added a debug print statement to show the final `voice_id` used, aiding in troubleshooting and transparency.