### PR TITLE
AWS bedrock support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Google Gemini API Configuration (optional)
 GEMINI_API_KEY=your_gemini_api_key_here
 
+# AWS Bedrock Configuration (optional - uses standard AWS credential chain)
+# Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or use AWS CLI profile/IAM role
+AWS_REGION=us-east-1
+
 # Twilio Configuration
 TWILIO_ACCOUNT_SID=your_twilio_account_sid_here
 TWILIO_AUTH_TOKEN=your_twilio_auth_token_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,14 +4,14 @@
 
 ## Project Overview
 
-**Twilio ConversationRelay BYOM (Bring Your Own Model)** — A FastAPI-based AI voice assistant that uses [Twilio ConversationRelay](https://www.twilio.com/docs/voice/twiml/connect/conversationrelay) to bridge phone calls with multiple LLM backends (OpenAI GPT, Google Gemini). Users configure the assistant's AI model, personality, and TTS voice through a web UI, then interact via inbound or outbound phone calls.
+**Twilio ConversationRelay BYOM (Bring Your Own Model)** — A FastAPI-based AI voice assistant that uses [Twilio ConversationRelay](https://www.twilio.com/docs/voice/twiml/connect/conversationrelay) to bridge phone calls with multiple LLM backends (OpenAI GPT, Google Gemini, AWS Bedrock/Amazon Nova). Users configure the assistant's AI model, personality, and TTS voice through a web UI, then interact via inbound or outbound phone calls.
 
 ### Key Technologies
 
 - **Runtime**: Python 3.12
 - **Framework**: FastAPI + Uvicorn
 - **Templating**: Jinja2
-- **AI SDKs**: `openai`, `google-genai`
+- **AI SDKs**: `openai`, `google-genai`, `boto3` (AWS Bedrock)
 - **Telephony**: Twilio Voice SDK (`twilio`), ConversationRelay (WebSocket-based)
 - **TTS Providers**: Twilio (default), Google TTS, Amazon Polly, ElevenLabs
 - **Frontend**: Vanilla HTML/CSS/JS (no build step)
@@ -58,10 +58,11 @@ All server logic lives in `main.py`. There is no separate router, service, or mo
                 │              │  Messages: setup → prompt → text response
                 └──────────────┘
                        │
-            ┌──────────┴──────────┐
-            ▼                     ▼
-      OpenAI API            Google Gemini API
-   (gpt-4o-mini/4o/4)    (gemini-2.5-pro/flash)
+            ┌──────────┼──────────────────┐
+            ▼          ▼                  ▼
+      OpenAI API  Google Gemini API  AWS Bedrock
+   (gpt-4o-mini/  (gemini-2.5-pro/  (nova-micro/
+     4o/4)          flash)            lite/pro)
 ```
 
 ### WebSocket Protocol (ConversationRelay)
@@ -120,6 +121,7 @@ The runtime configuration (`current_config`) has these fields:
 | `TWILIO_AUTH_TOKEN`    | Yes      | Twilio Auth Token                          |
 | `TWILIO_PHONE_NUMBER`  | Yes     | Twilio phone number (E.164 format)         |
 | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | No | Google Gemini API key          |
+| `AWS_REGION`          | No       | AWS region for Bedrock (default: `us-east-1`). Uses standard AWS credential chain (env vars, CLI profile, or IAM role) |
 | `NGROK_URL`           | Yes      | Public hostname (without `https://`) for WebSocket URL |
 | `PORT`                | No       | Server port (default: `8080`)              |
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # AI Voice Assistant with Web Configuration
 
-This project creates an intelligent voice assistant that uses [Twilio Voice](https://www.twilio.com/docs/voice) and [ConversationRelay](https://www.twilio.com/docs/voice/twiml/connect/conversationrelay) with multiple AI models including [OpenAI API](https://platform.openai.com/docs/api-reference/introduction) and [Google Gemini](https://ai.google.dev/). The assistant can engage in natural two-way conversations over phone calls with configurable personalities and AI models.
+This project creates an intelligent voice assistant that uses [Twilio Voice](https://www.twilio.com/docs/voice) and [ConversationRelay](https://www.twilio.com/docs/voice/twiml/connect/conversationrelay) with multiple AI models including [OpenAI API](https://platform.openai.com/docs/api-reference/introduction), [Google Gemini](https://ai.google.dev/), and [AWS Bedrock](https://docs.aws.amazon.com/bedrock/) (Amazon Nova). The assistant can engage in natural two-way conversations over phone calls with configurable personalities and AI models.
 
 ## Overview
 
 This application provides:
-- **Web Configuration Interface**: Select AI models (OpenAI GPT-4o, GPT-4, Gemini) and personality types
+- **Web Configuration Interface**: Select AI models (OpenAI GPT-4o, GPT-4, Gemini, AWS Nova) and personality types
 - **Inbound Calls**: Users can call your Twilio number to interact with the AI assistant
 - **Outbound Calls**: Initiate calls to users directly from the web interface
-- **Multiple AI Models**: Support for OpenAI GPT models and Google Gemini
+- **Multiple AI Models**: Support for OpenAI GPT models, Google Gemini, and AWS Bedrock (Amazon Nova)
 - **Personality Customization**: Choose from 8 different personality types or create custom prompts
 - **Real-time Configuration**: Changes apply immediately to new calls
 
@@ -19,6 +19,7 @@ This application provides:
 - A Twilio Number with Voice Capabilities: [Instructions to purchase a number](https://support.twilio.com/hc/en-us/articles/223180928-How-to-Buy-a-Twilio-Phone-Number)
 - **Required**: OpenAI Account and API Key: Visit [OpenAI's platform](https://platform.openai.com/api-keys)
 - **Optional**: Google AI Studio Account and API Key: Visit [Google AI Studio](https://aistudio.google.com/app/apikey) for Gemini models
+- **Optional**: AWS Account with Bedrock access: Visit [AWS Bedrock](https://aws.amazon.com/bedrock/) for Amazon Nova models
 - ngrok for local development: [Download ngrok](https://ngrok.com/)
 
 ## Installation
@@ -51,7 +52,10 @@ This application provides:
     
     # Optional - Google Gemini API Configuration
     GEMINI_API_KEY=your_gemini_api_key_here
-    
+
+    # Optional - AWS Bedrock Configuration (uses standard AWS credential chain)
+    AWS_REGION=us-east-1
+
     # Required - Ngrok Configuration (without https://)
     NGROK_URL=your-ngrok-url.ngrok.io
     ```
@@ -101,7 +105,7 @@ For a complete Azure deployment guide (including WebSocket support and troublesh
 1.  Open your browser and go to: `http://localhost:8080`
 
 2.  **Configure AI Settings:**
-    - Select your preferred AI model (OpenAI GPT-4o, GPT-4, or Gemini)
+    - Select your preferred AI model (OpenAI GPT-4o, GPT-4, Gemini, or AWS Nova)
     - Choose a personality type (Helpful, Friendly, Professional, Creative, etc.)
     - Optionally, add a custom system prompt
     - Click "Save Configuration"
@@ -151,7 +155,7 @@ Notes:
 2.  Twilio requests TwiML from `/twiml` endpoint
 3.  TwiML instructs Twilio to connect to WebSocket at `/ws`
 4.  Voice input is sent to the server via WebSocket
-5.  Server sends input to the configured AI model (OpenAI/Gemini)
+5.  Server sends input to the configured AI model (OpenAI/Gemini/Bedrock)
 6.  AI response is sent back to Twilio and converted to speech
 7.  Conversation continues until call ends
 
@@ -164,6 +168,7 @@ Notes:
 ### AI Model Selection
 - **OpenAI Models**: GPT-4o Mini (default), GPT-4o, GPT-4
 - **Google Gemini**: Gemini Pro, Gemini Flash
+- **AWS Bedrock (Amazon Nova)**: Nova Micro, Nova Lite, Nova Pro
 - Models are switched dynamically based on web configuration
 
 ## Project Structure
@@ -205,12 +210,17 @@ twilio-cr-ai/
    - Verify API keys are correctly set
    - For Gemini models, ensure `GEMINI_API_KEY` is configured
 
-3. **Calls not connecting**
+3. **AWS Bedrock model not working**
+   - Ensure AWS credentials are configured (via environment variables, AWS CLI profile, or IAM role)
+   - Verify you have enabled the Nova model(s) in the [AWS Bedrock console](https://console.aws.amazon.com/bedrock/)
+   - Check that your `AWS_REGION` is set to a region that supports Bedrock
+
+4. **Calls not connecting**
    - Confirm ngrok is running and URL is updated in `.env`
    - Check Twilio webhook configuration
    - Ensure phone numbers include country codes
 
-4. **Web interface not loading**
+5. **Web interface not loading**
    - Confirm server is running on port 8080
    - Check that `templates/` and `static/` directories exist
 
@@ -219,3 +229,4 @@ twilio-cr-ai/
 - Check [Twilio Documentation](https://www.twilio.com/docs) for Twilio-specific issues
 - Visit [OpenAI Documentation](https://platform.openai.com/docs) for API-related questions
 - Review [Gemini API Documentation](https://ai.google.dev/docs) for Gemini model issues
+- Consult [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/) for Bedrock/Nova model issues

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi import Request
 from pydantic import BaseModel
+import boto3
 from openai import OpenAI
 from dotenv import load_dotenv
 from google import genai
@@ -58,6 +59,13 @@ PERSONALITY_PROMPTS = {
 openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 gemini_api_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
 gemini_client = genai.Client(api_key=gemini_api_key) if gemini_api_key else None
+
+# Initialize AWS Bedrock client
+aws_region = os.getenv("AWS_REGION", "us-east-1")
+try:
+    bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+except Exception:
+    bedrock_client = None
 
 # Initialize Twilio client
 twilio_client = Client(os.getenv("TWILIO_ACCOUNT_SID"), os.getenv("TWILIO_AUTH_TOKEN"))
@@ -139,7 +147,34 @@ async def ai_response(messages):
                 )
             )
             return response.text
-            
+
+        elif current_config["aiModel"].startswith("bedrock"):
+            if not bedrock_client:
+                raise Exception("AWS Bedrock client not configured. Check your AWS credentials.")
+
+            model_map = {
+                "bedrock-nova-micro": "amazon.nova-micro-v1:0",
+                "bedrock-nova-lite": "amazon.nova-lite-v1:0",
+                "bedrock-nova-pro": "amazon.nova-pro-v1:0"
+            }
+            model_id = model_map.get(current_config["aiModel"], "amazon.nova-lite-v1:0")
+
+            # Build Bedrock converse API messages (separate system prompt)
+            system_prompt = [{"text": messages[0]["content"]}]
+            bedrock_messages = []
+            for msg in messages[1:]:
+                bedrock_messages.append({
+                    "role": msg["role"],
+                    "content": [{"text": msg["content"]}]
+                })
+
+            response = bedrock_client.converse(
+                modelId=model_id,
+                messages=bedrock_messages,
+                system=system_prompt
+            )
+            return response["output"]["message"]["content"][0]["text"]
+
     except Exception as e:
         print(f"Error with AI response: {e}")
         return "I'm sorry, I'm having trouble processing your request right now."

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ google-genai
 jinja2
 python-multipart
 twilio
+boto3

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,9 @@
                     <option value="openai-gpt4">OpenAI GPT-4</option>
                     <option value="gemini-pro">Google Gemini Pro</option>
                     <option value="gemini-flash">Google Gemini Flash</option>
+                    <option value="bedrock-nova-micro">AWS Nova Micro</option>
+                    <option value="bedrock-nova-lite">AWS Nova Lite</option>
+                    <option value="bedrock-nova-pro">AWS Nova Pro</option>
                 </select>
             </div>
 


### PR DESCRIPTION
This pull request adds support for AWS Bedrock (Amazon Nova) as a new AI backend alongside OpenAI and Google Gemini. The changes update documentation, configuration, and code to enable selection and use of AWS Bedrock models for AI voice conversations.

**Major enhancements:**

*Support for AWS Bedrock (Amazon Nova):*
- Added initialization of a `boto3` Bedrock client in `main.py`, using the `AWS_REGION` environment variable and standard AWS credential chain. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R10) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R63-R69)
- Implemented logic in `main.py` to route requests to AWS Bedrock based on selected model, mapping UI model names to Bedrock model IDs and formatting messages for Bedrock's API.
- Updated the web UI (`templates/index.html`) to allow selection of AWS Nova models (Micro, Lite, Pro) in the AI model dropdown.

*Documentation and configuration updates:*
- Updated `README.md` and `AGENTS.md` to document AWS Bedrock support, configuration steps, troubleshooting, and model selection. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R58) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L104-R108) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R158) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L208-R223) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R232) [[9]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L7-R14) [[10]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L61-R65) [[11]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R124)
- Added AWS Bedrock configuration section to `.env.example`, including instructions for setting the AWS region and credentials.

These changes make it possible to use AWS Bedrock (Amazon Nova) as an AI backend for phone conversations, with clear setup instructions and UI integration.